### PR TITLE
Fixed empty cart error

### DIFF
--- a/src/js/cart.js
+++ b/src/js/cart.js
@@ -2,8 +2,10 @@ import { getLocalStorage } from "./utils.mjs";
 
 function renderCartContents() {
   const cartItems = getLocalStorage("so-cart");
-  const htmlItems = cartItems.map((item) => cartItemTemplate(item));
-  document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  if(cartItems != null){
+    const htmlItems = cartItems.map((item) => cartItemTemplate(item));
+    document.querySelector(".product-list").innerHTML = htmlItems.join("");
+  }
 }
 
 function cartItemTemplate(item) {


### PR DESCRIPTION
This is a quick fix for the empty cart error. The logic now checks local storage to see if it is not empty. If it is not empty, then it will display the items in the cart. 